### PR TITLE
问题修复

### DIFF
--- a/UI/newUi/add-scene-panel.cpp
+++ b/UI/newUi/add-scene-panel.cpp
@@ -76,6 +76,7 @@ ComboBoxView::ComboBoxView(QWidget *parent) : QWidget(parent)
 	listWidget->setFocusPolicy(Qt::NoFocus);
 	listWidget->setGridSize(QSize(itemHeight, itemHeight));
 	listWidget->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
+	listWidget->setSelectionMode(QAbstractItemView::NoSelection);
 
 	QHBoxLayout *layout = new QHBoxLayout(this);
 	layout->setContentsMargins(shadowBorder, shadowBorder, shadowBorder,
@@ -460,17 +461,19 @@ void IpCameraSettingsWidget::initUi()
 	lineedit_rtsp = new QLineEdit(this);
 	lineedit_rtsp->setFixedSize(410 * getScale(), 51 * getScale());
 	lineedit_rtsp->setStyleSheet(
-		QString("QLineEdit{ background-color:rgb(240,240,240); border: none; color: rgb(68, 68, 68);border-radius: %1px; %2}"
+		QString("QLineEdit{ background-color:rgb(240,240,240); border: none; color: rgb(68, 68, 68);border-radius: %1px; padding-left: %3px; %2}"
 			"QLineEdit::hover{background-color: rgb(240,240,240);}"
 			"QLineEdit::disabled{color: rgb(170, 170, 170);}")
 			.arg(4 * getScale())
-			.arg(getFontStyle(18)));
+			.arg(getFontStyle(18))
+			.arg(21 * getScale()));
 	lineedit_rtsp->setPlaceholderText(QTStr("NewUi.Input") + "RTSP");
 	lineedit_rtsp->setFont(getFont(18));
 	QPalette palette = lineedit_rtsp->palette();
 	palette.setColor(QPalette::Normal, QPalette::PlaceholderText,
 			 QColor(170, 170, 170));
 	lineedit_rtsp->setPalette(palette);
+	lineedit_rtsp->setContextMenuPolicy(Qt::NoContextMenu);
 
 	QHBoxLayout *hlayout_1 = new QHBoxLayout;
 	hlayout_1->setContentsMargins(0, 0, 0, 0);
@@ -1255,44 +1258,50 @@ void StreamingSettingsPanel::initUi()
 	lineedit_rtsp1->setFixedSize(340 * getScale(), 51 * getScale());
 	lineedit_rtsp1->setEnabled(true);
 	lineedit_rtsp1->setStyleSheet(
-		QString("QLineEdit{ background-color:rgb(240,240,240); border: none; color: rgb(68, 68, 68);border-radius: %1px; %2}"
+		QString("QLineEdit{ background-color:rgb(240,240,240); border: none; color: rgb(68, 68, 68);border-radius: %1px; padding-left: %3px; %2}"
 			"QLineEdit::hover{background-color: rgb(240,240,240);}"
 			"QLineEdit::disabled{color: rgb(170, 170, 170);}")
 			.arg(4 * getScale())
-			.arg(getFontStyle(18)));
+			.arg(getFontStyle(18))
+			.arg(21 * getScale()));
 	lineedit_rtsp1->setPlaceholderText(QTStr("NewUi.Input") + "RTMP1");
 	lineedit_rtsp1->move(30 * getScale(), 123 * getScale());
 	QPalette palette = lineedit_rtsp1->palette();
 	palette.setColor(QPalette::PlaceholderText, QColor(170, 170, 170));
 	lineedit_rtsp1->setPalette(palette);
+	lineedit_rtsp1->setContextMenuPolicy(Qt::NoContextMenu);
 
 	lineedit_rtsp2 = new QLineEdit(this);
 	lineedit_rtsp2->setFixedSize(340 * getScale(), 51 * getScale());
 	lineedit_rtsp2->setEnabled(false);
 	lineedit_rtsp2->setStyleSheet(
-		QString("QLineEdit{ background-color:rgb(240,240,240); border: none; color: rgb(68, 68, 68);border-radius: %1px; %2}"
+		QString("QLineEdit{ background-color:rgb(240,240,240); border: none; color: rgb(68, 68, 68);border-radius: %1px;  padding-left: %3px; %2}"
 			"QLineEdit::hover{background-color: rgb(240,240,240);}"
 			"QLineEdit::disabled{color: rgb(170, 170, 170);}")
 			.arg(4 * getScale())
-			.arg(getFontStyle(18)));
+			.arg(getFontStyle(18))
+			.arg(21 * getScale()));
 	lineedit_rtsp2->setPlaceholderText(QTStr("NewUi.Input") + "RTMP2");
 	lineedit_rtsp2->setFont(getFont(18));
 	lineedit_rtsp2->move(30 * getScale(), 241 * getScale());
 	lineedit_rtsp2->setPalette(lineedit_rtsp1->palette());
+	lineedit_rtsp2->setContextMenuPolicy(Qt::NoContextMenu);
 
 	lineedit_rtsp3 = new QLineEdit(this);
 	lineedit_rtsp3->setFixedSize(340 * getScale(), 51 * getScale());
 	lineedit_rtsp3->setEnabled(false);
 	lineedit_rtsp3->setStyleSheet(
-		QString("QLineEdit{ background-color:rgb(240,240,240); border: none; color: rgb(68, 68, 68);border-radius: %1px; %2}"
+		QString("QLineEdit{ background-color:rgb(240,240,240); border: none; color: rgb(68, 68, 68);border-radius: %1px;  padding-left: %3px; %2}"
 			"QLineEdit::hover{background-color: rgb(240,240,240);}"
 			"QLineEdit::disabled{color: rgb(170, 170, 170);}")
 			.arg(4 * getScale())
-			.arg(getFontStyle(18)));
+			.arg(getFontStyle(18))
+			.arg(21 * getScale()));
 	lineedit_rtsp3->setPlaceholderText(QTStr("NewUi.Input") + "RTMP3");
 	lineedit_rtsp3->setFont(getFont(18));
 	lineedit_rtsp3->move(30 * getScale(), 359 * getScale());
 	lineedit_rtsp3->setPalette(lineedit_rtsp1->palette());
+	lineedit_rtsp3->setContextMenuPolicy(Qt::NoContextMenu);
 
 	QCheckBox *checkbox_rtsp1 = new QCheckBox(this);
 	checkbox_rtsp1->setFixedSize(42 * getScale(), 24 * getScale());

--- a/UI/newUi/window-panel.cpp
+++ b/UI/newUi/window-panel.cpp
@@ -13,6 +13,19 @@ OBSPanelItem::OBSPanelItem(int type, const QString &name, int index,
 	this->initUi();
 }
 
+bool OBSPanelItem::eventFilter(QObject *obj, QEvent *event)
+{
+	if (event->type() == QEvent::MouseButtonRelease) {
+		QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
+		if (mouseEvent->button() == Qt::LeftButton) {
+			qDebug() << "----button click";
+			checkbox->click();
+		}
+			
+	}
+	return QWidget::eventFilter(obj, event);
+}
+
 void OBSPanelItem::initUi()
 {
 	QHBoxLayout *hlayout = new QHBoxLayout(this);

--- a/UI/newUi/window-panel.hpp
+++ b/UI/newUi/window-panel.hpp
@@ -21,6 +21,9 @@ public:
 	inline QAbstractButton *getCheckButton() { return checkbox; }
 	void setIndex(int index) { m_index = index; }
 
+protected:
+	bool eventFilter(QObject *obj, QEvent *event) override;
+
 private:
 	int m_type;
 	int m_index;

--- a/UI/newUi/window-toolbar.cpp
+++ b/UI/newUi/window-toolbar.cpp
@@ -1,10 +1,9 @@
 #include "window-toolbar.hpp"
-#include <qlabel.h>
 #include <qcheckbox.h>
-#include <qpushbutton.h>
 #include <qpainter.h>
 #include <qlayout.h>
 #include <qdebug.h>
+#include <qevent.h>
 #include "font.hpp"
 #include "obs-app.hpp"
 
@@ -22,6 +21,49 @@ void OBSToolbar::paintEvent(QPaintEvent *event)
 
 	painter.fillRect(this->rect(), QColor(68, 68, 68));
 	return QWidget::paintEvent(event);
+}
+
+bool OBSToolbar::eventFilter(QObject *obj, QEvent *event)
+{
+	if ((obj == pBtn_settings_stream ||
+		obj == label_settings_stream) &&
+	    event->type() == QEvent::Enter) {
+		pBtn_settings_stream->setStyleSheet(
+			QString("QPushButton{ padding: 0px; border: none; background-color: transparent;"
+				"border-image: url(':/res/images/newUi/settings2@2x.png'); "
+				"min-width: %1; min-height: %1;}")
+				.arg(16 * getScale()));
+		label_settings_stream->setStyleSheet(
+			QString("QLabel{ color: white; padding-left: %2px; %1}")
+				.arg(getFontStyle(12))
+				.arg(3 * getScale()));
+	} else if ((obj == pBtn_settings_stream ||
+		    obj == label_settings_stream) &&
+		   event->type() == QEvent::Leave) {
+		//QMouseEvent *mouseEvent =
+		//	static_cast<QMouseEvent *>(event);
+		//if (pBtn_settings_stream->rect().contains(mouseEvent->pos()) ||
+		//    label_settings_stream->rect().contains(mouseEvent->pos()))
+		//	return QWidget::eventFilter(obj, event);
+		
+		pBtn_settings_stream->setStyleSheet(
+			QString("QPushButton{ padding: 0px; border: none; background-color: transparent;"
+				"border-image: url(':/res/images/newUi/settings@2x.png'); "
+				"min-width: %1; min-height: %1;}")
+				.arg(16 * getScale()));
+		label_settings_stream->setStyleSheet(
+			QString("QLabel{ color: rgb(170,170,170); padding-left: %2px; %1}")
+				.arg(getFontStyle(12))
+				.arg(3 * getScale()));
+	} else if ((obj == pBtn_settings_stream ||
+		    obj == label_settings_stream) &&
+		   event->type() == QEvent::MouseButtonRelease) {
+		QMouseEvent *mouseEvent =
+			static_cast<QMouseEvent *>(event);
+		if (mouseEvent->button() == Qt::LeftButton)
+			emit showStreamPanel();
+	}
+	return QWidget::eventFilter(obj, event);
 }
 
 void OBSToolbar::initUi()
@@ -89,16 +131,14 @@ void OBSToolbar::initUi()
 	label_2->setStyleSheet(
 		QString("QLabel{ color: white; %1}").arg(getFontStyle(14)));
 
-	QPushButton *pBtn_settings_stream = new QPushButton(this);
+	pBtn_settings_stream = new QPushButton(this);
 	pBtn_settings_stream->setFixedSize(16 * getScale(), 16 * getScale());
 	pBtn_settings_stream->setStyleSheet(
 		QString("QPushButton{ padding: 0px; border: none; background-color: transparent;"
 			"border-image: url(':/res/images/newUi/settings@2x.png'); "
-			"min-width: %1; min-height: %1;}"
-			"QPushButton::hover{border-image: url(':/res/images/newUi/settings2@2x.png');}")
+			"min-width: %1; min-height: %1;}")
 			.arg(16 * getScale()));
-	connect(pBtn_settings_stream, &QPushButton::clicked, this,
-		[=]() { emit showStreamPanel(); });
+	pBtn_settings_stream->installEventFilter(this);
 
 	QCheckBox *checkbox_stream = new QCheckBox(this);
 	checkbox_stream->setFixedSize(42 * getScale(), 24 * getScale());
@@ -117,11 +157,12 @@ void OBSToolbar::initUi()
 			//	pBtn_settings_stream->setEnabled(true);
 		});
 
-	QLabel *label_settings_stream = new QLabel(this);
+	label_settings_stream = new QLabel(this);
 	label_settings_stream->setText(QTStr("NewUi.Settings"));
+	label_settings_stream->installEventFilter(this);
 	label_settings_stream->setStyleSheet(
-		QString("QLabel{ color: rgb(170,170,170); %1}")
-			.arg(getFontStyle(12)));
+		QString("QLabel{ color: rgb(170,170,170); padding-left: %2px; %1}")
+			.arg(getFontStyle(12)).arg(3 * getScale()));
 
 	QHBoxLayout *layout = new QHBoxLayout(this);
 	layout->setSpacing(0);
@@ -163,8 +204,8 @@ void OBSToolbar::initUi()
 	layout->addSpacerItem(
 		new QSpacerItem(10 * getScale(), 1, QSizePolicy::Fixed));
 	layout->addWidget(pBtn_settings_stream, 0, Qt::AlignVCenter);
-	layout->addSpacerItem(
-		new QSpacerItem(10 * getScale(), 1, QSizePolicy::Fixed));
+	//layout->addSpacerItem(
+	//	new QSpacerItem(6 * getScale(), 1, QSizePolicy::Fixed));
 	layout->addWidget(label_settings_stream, 0, Qt::AlignVCenter);
 	layout->addSpacerItem(new QSpacerItem(1, 1, QSizePolicy::Expanding));
 }

--- a/UI/newUi/window-toolbar.hpp
+++ b/UI/newUi/window-toolbar.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <QWidget>
+#include <qpushbutton.h>
+#include <qlabel.h>
 
 class OBSToolbar : public QWidget {
 	Q_OBJECT
@@ -11,9 +13,13 @@ public:
 
 protected:
 	void paintEvent(QPaintEvent *event);
+	bool eventFilter(QObject *obj, QEvent *event) override;
 
 private:
 	void initUi();
+
+	QPushButton *pBtn_settings_stream;
+	QLabel *label_settings_stream;
 
 signals:
 	void showStreamPanel();


### PR DESCRIPTION
1、去掉选中字体右键出现英文菜单。
2、增加画中画等面板Item单击可被选中。
3、修复部分输入框字符间距问题。
4、修复推流设置只有图标可被点击问题，文本也可点击。
5、修复下拉列表触摸选中出现蓝色背景问题。